### PR TITLE
small fixes for problems I ran into with the clipper card

### DIFF
--- a/src/com/codebutler/farebot/Utils.java
+++ b/src/com/codebutler/farebot/Utils.java
@@ -101,7 +101,7 @@ public class Utils
     
     public static long byteArrayToLong(byte[] b, int offset, int length) {
         long value = 0;
-        for (int i = 0; i < length; i++) {
+        for (int i = 0; i < length  && i < b.length; i++) {
             int shift = (length - 1 - i) * 8;
             value += (b[i + offset] & 0x000000FF) << shift;
         }

--- a/src/com/codebutler/farebot/activities/CardInfoActivity.java
+++ b/src/com/codebutler/farebot/activities/CardInfoActivity.java
@@ -64,7 +64,12 @@ public class CardInfoActivity extends TabActivity
             return;
         }
 
-        TransitData transitData = mCard.parseTransitData();
+        TransitData transitData = null;
+        try {
+            transitData = mCard.parseTransitData();
+        } catch (Exception ex) {
+            Utils.showErrorAndFinish(this, ex);
+        }
         if (transitData == null) {
             showAdvancedInfo();
             finish();


### PR DESCRIPTION
Hi!  I just built farebot at head and loaded it on my phone.  It reads my clipper card wonderfully!

This patch prevents farebot from crashing when you pull away the card too soon.  I noticed that if you pull the card out of range while the progress wheel is still spinning, I could trigger an array out-of-bounds exception.  I tracked that down to the code in this change.  It does two things: 1) more thorough bounds protection in the place where the out of bounds was happening; 2) wrap the call site with your alert-and-exit logic.

It may judicious to also prevent this error with checks in ClipperTransitData's createTrips and createRefill, or to somehow bail out entirely with a nicer user message that the read wasn't complete.  I haven't really digested the code enough to make that judgement or to write that patch yet.

Cheers,
Mike
