### PR TITLE
Added Fremont Station (0x25) to Clipper list.

### DIFF
--- a/src/com/codebutler/farebot/transit/ClipperTransitData.java
+++ b/src/com/codebutler/farebot/transit/ClipperTransitData.java
@@ -100,7 +100,7 @@ public class ClipperTransitData extends TransitData
             put((long)0x22, new Station("Hayward Station",                     "Hayward",              "37.670387", "-122.088002"));
             put((long)0x23, new Station("South Hayward Station",               "South Hayward",        "37.634800", "-122.057551"));
             put((long)0x24, new Station("Union City Station",                  "Union City",           "37.591203", "-122.017854"));
-			put((long)0x25, new Station("Fremont Station",                     "Fremont",              "37.557727", "-121.976395"));
+            put((long)0x25, new Station("Fremont Station",                     "Fremont",              "37.557727", "-121.976395"));
             put((long)0x26, new Station("Daly City Station",                   "Daly City",            "37.7066",   "-122.4696"));
             put((long)0x28, new Station("South San Francisco Station",         "South SF",             "37.6744",   "-122.442"));
             put((long)0x29, new Station("San Bruno Station",                   "San Bruno",            "37.63714",  "-122.415622"));


### PR DESCRIPTION
Got the ID from my phone (Galaxy Nexus). Lat/Long is from Google Maps. Second commit because I forgot to set my home dev editor to spacify tabs.

Also, the app seems to have some difficulty handling cards with multiple protocols. I have a Visa payWave credit card (issued in Taiwan) that has both ISO 14443 (for running the credit card app) as well as MIFARE Classic. farebot just replies with Invalid response when scanning it. Screenshots from the NXP diagnostic app:

http://home.comcast.net/~jashsu/demo/Screenshot_2012-04-26-00-17-17.png
http://home.comcast.net/~jashsu/demo/Screenshot_2012-04-26-00-17-46.png
