### PR TITLE
add 12th Street Station, Oakland

### DIFF
--- a/src/com/codebutler/farebot/transit/ClipperTransitData.java
+++ b/src/com/codebutler/farebot/transit/ClipperTransitData.java
@@ -89,6 +89,7 @@ public class ClipperTransitData extends TransitData {
         put((long)0x08, new Station("Powell Street Station",                     "Powell St.",           "37.784970", "-122.40701"));
         put((long)0x09, new Station("Montgomery St. Station",                    "Montgomery",           "37.789336", "-122.401486"));
         put((long)0x0a, new Station("Embarcadero Station",                       "Embarcadero",          "37.793086", "-122.396276"));
+        put((long)0x0c, new Station("12th Street Oakland City Center",           "12th St.",             "37.802956", "-122.2720367"));
         put((long)0x0d, new Station("19th Street Oakland Station",               "19th St.",             "37.80762",  "-122.26886"));
         put((long)0x0f, new Station("Rockridge Station",                         "Rockridge",            "37.84463",  "-122.251825"));
         put((long)0x13, new Station("Walnut Creek Station",                      "Walnut Creek",         "37.90563",  "-122.06744"));


### PR DESCRIPTION
this patch adds station code `0x0c` as [12th Street Oakland City Center](http://bart.gov/stations/12th/index.aspx) station to the BART/Clipper Card table. The data should be good; I pulled the station ID from my phone and the lat/long from [OpenStreetMap](http://www.openstreetmap.org/browse/node/2150077203).

I did notice, however, that it seems reasonable to guess most of the missing BART station IDs: `0x0b` is probably West Oakland, the only station between Embarcadero (`0x0a`) and 12th Street, and so on. If you would accept such a patch based on inference rather than real-world data collection, I'd be happy to prepare one.

Thanks!
