### PR TITLE
Added and corrected Clipper stations

### DIFF
--- a/src/main/java/com/codebutler/farebot/transit/ClipperTransitData.java
+++ b/src/main/java/com/codebutler/farebot/transit/ClipperTransitData.java
@@ -92,7 +92,7 @@ public class ClipperTransitData extends TransitData {
         put((long)0x0b, new Station("West Oakland Station",                      "West Oakland",         "37.805296", "-122.294938"));
         put((long)0x0c, new Station("12th Street Oakland City Center",           "12th St.",             "37.802956", "-122.2720367"));
         put((long)0x0d, new Station("19th Street Oakland Station",               "19th St.",             "37.80762",  "-122.26886"));
-	put((long)0x0e, new Station("MacArthur Station",                         "MacArthur",            "37.82928",  "-122.26661"));
+        put((long)0x0e, new Station("MacArthur Station",                         "MacArthur",            "37.82928",  "-122.26661"));
         put((long)0x0f, new Station("Rockridge Station",                         "Rockridge",            "37.84463",  "-122.251825"));
         put((long)0x13, new Station("Walnut Creek Station",                      "Walnut Creek",         "37.90563",  "-122.06744"));
         put((long)0x14, new Station("Concord Station",                           "Concord",              "37.97376",  "-122.02903"));


### PR DESCRIPTION
The station codes for West Oakland and MacArthur BART stations weren't present. Also, the code for the Ashby Station was incorrectly reported as Pittsburgh/Bay Pt.
