### PR TITLE
Update for AStudio 1.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,18 +4,20 @@ buildscript {
         maven { url 'http://download.crashlytics.com/maven' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.2'
-        classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.14.2'
+        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.14.3'
+    }
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+        maven { url 'http://download.crashlytics.com/maven' }
     }
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'crashlytics'
-
-repositories {
-    mavenCentral()
-    maven { url 'http://download.crashlytics.com/maven' }
-}
 
 dependencies {
     compile 'com.android.support:support-v4:20.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
[Migrating to AStudio 1.+](http://tools.android.com/tech-docs/new-build-system/migrating-to-1-0-0) requires upgrade to gradle plugin and wrapper version.
Crashlytics also needs to be upgraded correspondingly, otherwise it will complain about `runProguard` which is already depcrecated.