### PR TITLE
A quick fix crash when reading Singapore NETS Flashpay

### DIFF
--- a/src/main/java/com/codebutler/farebot/card/cepas/CEPASProtocol.java
+++ b/src/main/java/com/codebutler/farebot/card/cepas/CEPASProtocol.java
@@ -22,14 +22,15 @@
 
 package com.codebutler.farebot.card.cepas;
 
+import com.codebutler.farebot.util.Utils;
 import android.nfc.tech.IsoDep;
 import android.util.Log;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class CEPASProtocol {
     private static final String TAG = "CEPASProtocol";
+    private static final String CEPAS_SELECT_FILE_COMMAND = "00A40000024000";
 
     /* Status codes */
     private static final byte OPERATION_OK      = (byte) 0x00;
@@ -43,6 +44,7 @@ public class CEPASProtocol {
 
     public CEPASPurse getPurse(int purseId) throws IOException {
         try {
+            sendSelectFile();
             byte[] purseBuff = sendRequest((byte) 0x32, (byte) (purseId), (byte) 0, (byte) 0, new byte[] { (byte) 0 });
             if (purseBuff != null) {
                 return new CEPASPurse(purseId, purseBuff);
@@ -89,6 +91,10 @@ public class CEPASProtocol {
             Log.w(TAG, "Error reading purse history " + purseId, ex);
             return new CEPASHistory(purseId, ex.getMessage());
         }
+    }
+
+    private byte[] sendSelectFile() throws IOException{
+        return mTagTech.transceive(Utils.hexStringToByteArray(CEPAS_SELECT_FILE_COMMAND));
     }
 
     private byte[] sendRequest(byte command, byte p1, byte p2, byte lc, byte[] parameters) throws CEPASException,


### PR DESCRIPTION
Now in Singapore, there are many credit cards which contain Nets Flashpay application. However farebot cannot read them correctly. The app crashes with the log:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'byte[] com.codebutler.farebot.xml.HexString.getData()' on a null object reference
at com.codebutler.farebot.card.cepas.CEPASPurse.getCAN(CEPASPurse.java:223)
```

This pull request commits a quick fix by adding select file command before scanning purse files. These credit card with Nets Flashpay can be recognized successfully as Nets card.

I also test this patch with regular EZlink card, it works well too. More tests on more types of CEPAS card are appreciated. 

