### PR TITLE
Add nickname feature, add option to squash dupes

### DIFF
--- a/src/main/java/com/codebutler/farebot/card/Card.java
+++ b/src/main/java/com/codebutler/farebot/card/Card.java
@@ -45,6 +45,7 @@ public abstract class Card {
     @Attribute(name="type") private CardType mType;
     @Attribute(name="id") private HexString mTagId;
     @Attribute(name="scanned_at") private Date mScannedAt;
+    @Attribute(name="nickname", required=false) private String mNickname;
 
     protected Card() { }
 
@@ -52,6 +53,13 @@ public abstract class Card {
         mType = type;
         mTagId = new HexString(tagId);
         mScannedAt = scannedAt;
+    }
+
+    protected Card(CardType type, byte[] tagId, Date scannedAt, String nick) {
+        mType = type;
+        mTagId = new HexString(tagId);
+        mScannedAt = scannedAt;
+        mNickname = nick;
     }
 
     public static Card dumpTag(byte[] tagId, Tag tag) throws Exception {
@@ -98,6 +106,23 @@ public abstract class Card {
 
     public Date getScannedAt() {
         return mScannedAt;
+    }
+
+    public void setNickname(String nick){
+        mNickname = nick;
+    }
+
+    public String getNickname() {
+        if(mNickname == null){
+            TransitData data = parseTransitData();
+            String titleSerial = (data.getSerialNumber() != null) ? data.getSerialNumber()
+                    : Utils.getHexString(getTagId(), "");
+        }
+        return mNickname;
+    }
+
+    public boolean hasNickname(){
+        return mNickname != null;
     }
 
     public abstract TransitIdentity parseTransitIdentity();

--- a/src/main/java/com/codebutler/farebot/fragment/CardsFragment.java
+++ b/src/main/java/com/codebutler/farebot/fragment/CardsFragment.java
@@ -217,6 +217,7 @@ public class CardsFragment extends ListFragment {
            int type = cursor.getInt(cursor.getColumnIndex(CardsTableColumns.TYPE));
            String serial = cursor.getString(cursor.getColumnIndex(CardsTableColumns.TAG_SERIAL));
            Date scannedAt = new Date(cursor.getLong(cursor.getColumnIndex(CardsTableColumns.SCANNED_AT)));
+           String nickname = cursor.getString(cursor.getColumnIndex(CardsTableColumns.NICKNAME));
 
            String cacheKey = serial + scannedAt.getTime();
 
@@ -237,7 +238,9 @@ public class CardsFragment extends ListFragment {
            TextView textView2 = (TextView) view.findViewById(android.R.id.text2);
 
            if (identity != null) {
-               if (identity.getSerialNumber() != null) {
+               if (nickname != null){
+                   textView1.setText(String.format("%s: %s", identity.getName(), nickname));
+               } else if (identity.getSerialNumber() != null) {
                    textView1.setText(String.format("%s: %s", identity.getName(), identity.getSerialNumber()));
                } else {
                    // textView1.setText(identity.getName());

--- a/src/main/java/com/codebutler/farebot/provider/CardsTableColumns.java
+++ b/src/main/java/com/codebutler/farebot/provider/CardsTableColumns.java
@@ -34,4 +34,5 @@ public class CardsTableColumns implements BaseColumns {
     public static final String TAG_SERIAL = "serial";
     public static final String DATA       = "data";
     public static final String SCANNED_AT = "scanned_at";
+    public static final String NICKNAME   = "nickname";
 }

--- a/src/main/java/com/codebutler/farebot/transit/TransitData.java
+++ b/src/main/java/com/codebutler/farebot/transit/TransitData.java
@@ -31,6 +31,7 @@ import java.util.List;
 public abstract class TransitData implements Parcelable {
     public abstract String getBalanceString();
     public abstract String getSerialNumber();
+    public boolean hasSerialNumber() { return true; };
     public abstract Trip[] getTrips();
     public abstract Refill[] getRefills();
     public abstract Subscription[] getSubscriptions();

--- a/src/main/java/com/codebutler/farebot/transit/bilhete_unico/BilheteUnicoSPTransitData.java
+++ b/src/main/java/com/codebutler/farebot/transit/bilhete_unico/BilheteUnicoSPTransitData.java
@@ -106,6 +106,10 @@ public class BilheteUnicoSPTransitData extends TransitData {
         return null;
     }
 
+    @Override public boolean hasSerialNumber() {
+        return false;
+    }
+
     @Override public Trip[] getTrips() {
         return null;
     }

--- a/src/main/java/com/codebutler/farebot/transit/clipper/ClipperData.java
+++ b/src/main/java/com/codebutler/farebot/transit/clipper/ClipperData.java
@@ -15,6 +15,7 @@ final class ClipperData {
     static final int AGENCY_MUNI         = 0x12;
     static final int AGENCY_GG_FERRY     = 0x19;
     static final int AGENCY_SF_BAY_FERRY = 0x1b;
+    static final int AGENCY_WHOLE_FOODS  = 0x302;
 
     static final Map<Integer, String> AGENCIES = new ImmutableMapBuilder<Integer, String>()
         .put(AGENCY_ACTRAN,       "Alameda-Contra Costa Transit District")
@@ -26,10 +27,11 @@ final class ClipperData {
         .put(AGENCY_MUNI,         "San Francisco Municipal")
         .put(AGENCY_GG_FERRY,     "Golden Gate Ferry")
         .put(AGENCY_SF_BAY_FERRY, "San Francisco Bay Ferry")
+        .put(AGENCY_WHOLE_FOODS,  "Whole Foods Grocery Store")
         .build();
 
     static final Map<Integer, String> SHORT_AGENCIES = new ImmutableMapBuilder<Integer, String>()
-        .put(AGENCY_ACTRAN, "ACTransit")
+        .put(AGENCY_ACTRAN,       "ACTransit")
         .put(AGENCY_BART,         "BART")
         .put(AGENCY_CALTRAIN,     "Caltrain")
         .put(AGENCY_GGT,          "GGT")
@@ -38,6 +40,7 @@ final class ClipperData {
         .put(AGENCY_MUNI,         "Muni")
         .put(AGENCY_GG_FERRY,     "GG Ferry")
         .put(AGENCY_SF_BAY_FERRY, "SF Bay Ferry")
+        .put(AGENCY_WHOLE_FOODS,  "Whole Foods")
         .build();
 
     static final Map<Long, Station> BART_STATIONS = new ImmutableMapBuilder<Long, Station>()

--- a/src/main/java/com/codebutler/farebot/transit/ovc/OVChipTransitData.java
+++ b/src/main/java/com/codebutler/farebot/transit/ovc/OVChipTransitData.java
@@ -288,6 +288,10 @@ public class OVChipTransitData extends TransitData {
         return null;
     }
 
+    @Override public boolean hasSerialNumber() {
+        return false;
+    }
+
     @Override public Trip[] getTrips() {
         return mTrips;
     }

--- a/src/main/java/com/codebutler/farebot/transit/suica/SuicaTransitData.java
+++ b/src/main/java/com/codebutler/farebot/transit/suica/SuicaTransitData.java
@@ -115,6 +115,10 @@ public class SuicaTransitData extends TransitData {
         return null;
     }
 
+    @Override public boolean hasSerialNumber() {
+        return false;
+    }
+
     @Override public Trip[] getTrips() {
         return mTrips;
     }

--- a/src/main/res/menu/card_info_menu.xml
+++ b/src/main/res/menu/card_info_menu.xml
@@ -22,6 +22,8 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+id/advanced_info"
+  <item android:id="@+id/nickname_card"
+          android:title="Nickname Card" />
+  <item android:id="@+id/advanced_info"
           android:title="@string/advanced_info" />
 </menu>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -29,6 +29,10 @@
             android:title="@string/launch_from_background"
             android:persistent="false"
             android:key="pref_launch_from_background"/>
+        <CheckBoxPreference
+            android:title="Overwrite Card Data"
+            android:summary="On duplicate cards, overwrite old data rather than creating new data"
+            android:key="pref_overwrite_card_data" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/accessibility">
         <CheckBoxPreference


### PR DESCRIPTION
This adds a feature that allows you to nickname cards, where the
nickname will be displayed instead of the serial number.

Also added is an option to overwrite current cards that match the
scanned card's serial number, rather than creating a new entry. If this
is turned on while there are already duplicate cards in the database, it
will only overwrite the latest-scanned card to avoid unintended data
loss.

Also adds whole foods to the agencies for refill data.

I took the liberty of cleaning up some logic relating to the serial number
as I needed to simplify for the nickname display logic. 
