### PR TITLE
Upgrade to auto-value-parcel 0.2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     provided 'com.google.auto.value:auto-value:1.3-rc1'
     apt 'com.google.auto.value:auto-value:1.3-rc1'
-    apt 'com.ryanharter.auto.value:auto-value-parcel:0.2.3-SNAPSHOT'
+    apt 'com.ryanharter.auto.value:auto-value-parcel:0.2.5'
     apt 'com.ryanharter.auto.value:auto-value-gson:0.4.0'
 }
 


### PR DESCRIPTION
This allows gradle to find the dependency with clean builds.