### PR TITLE
Add Kitsap Transit to ORCA

### DIFF
--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
@@ -47,6 +47,7 @@ public abstract class OrcaTransitInfo extends TransitInfo {
     static final int AGENCY_CT = 0x02;
     static final int AGENCY_WSF = 0x08;
     static final int AGENCY_ET = 0x03;
+    static final int AGENCY_KT = 0x05;
 
     @NonNull
     @Override

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
@@ -123,6 +123,8 @@ public abstract class OrcaTrip extends Trip {
                 return resources.getString(R.string.transit_orca_agency_wsf);
             case OrcaTransitInfo.AGENCY_ET:
                 return resources.getString(R.string.transit_orca_agency_et);
+            case OrcaTransitInfo.AGENCY_KT:
+                return resources.getString(R.string.transit_orca_agency_kt);
         }
         return resources.getString(R.string.transit_orca_agency_unknown, Long.toString(getAgency()));
     }
@@ -142,6 +144,8 @@ public abstract class OrcaTrip extends Trip {
                 return "WSF";
             case OrcaTransitInfo.AGENCY_ET:
                 return "ET";
+            case OrcaTransitInfo.AGENCY_KT:
+                return "KT";
         }
         return resources.getString(R.string.transit_orca_agency_unknown, Long.toString(getAgency()));
     }

--- a/farebot-transit-orca/src/main/res/values/strings.xml
+++ b/farebot-transit-orca/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="transit_orca_agency_st">Sound Transit</string>
     <string name="transit_orca_agency_wsf">Washington State Ferries</string>
     <string name="transit_orca_agency_et">Everett Transit</string>
+    <string name="transit_orca_agency_kt">Kitsap Transit</string>
     <string name="transit_orca_agency_unknown">Unknown Agency: %s</string>
 
     <string name="transit_orca_route_link">Link Light Rail</string>


### PR DESCRIPTION
Rode two buses and the fast ferry (using a [PFTP](https://www.flickr.com/photos/viriyincy/3561731244/)); all showed up as agency 5.