### PR TITLE
A few ORCA fixes

### DIFF
--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitFactory.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitFactory.java
@@ -75,7 +75,7 @@ public class OrcaTransitFactory implements TransitFactory<DesfireCard, OrcaTrans
 
         try {
             data = ((StandardDesfireFile) card.getApplication(0xffffff).getFile(0x0f)).getData().bytes();
-            serialNumber = ByteUtils.byteArrayToInt(data, 5, 3);
+            serialNumber = ByteUtils.byteArrayToInt(data, 4, 4);
         } catch (Exception ex) {
             throw new RuntimeException("Error parsing ORCA serial", ex);
         }

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
@@ -48,6 +48,11 @@ public abstract class OrcaTransitInfo extends TransitInfo {
     static final int AGENCY_WSF = 0x08;
     static final int AGENCY_ET = 0x03;
 
+    static final int FTP_TYPE_WSF = 0x08;
+    static final int FTP_TYPE_SOUNDER = 0x09;
+    static final int FTP_TYPE_BUS = 0x80;
+    static final int FTP_TYPE_LINK = 0xFB;
+
     @NonNull
     @Override
     public String getCardName(@NonNull Resources resources) {

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
@@ -97,7 +97,8 @@ public abstract class OrcaTrip extends Trip {
                 | (usefulData[6] << 4)
                 | (usefulData[7] >> 4);
 
-        long coachNumber = ((usefulData[9] & 0xf) << 12) | (usefulData[10] << 4) | ((usefulData[11] & 0xf0) >> 4);
+        long ftpType = ((usefulData[7] & 0xf) << 4) | ((usefulData[8] & 0xf0) >> 4);
+        long coachNumber = ((usefulData[8] & 0xf) << 20) | (usefulData[9] << 12) | (usefulData[10] << 4) | ((usefulData[11] & 0xf0) >> 4);
 
         long fare;
         if (usefulData[15] == 0x00 || usefulData[15] == 0xFF) {
@@ -111,7 +112,7 @@ public abstract class OrcaTrip extends Trip {
         long agency = usefulData[3] >> 4;
         long transType = (usefulData[17]);
 
-        return new AutoValue_OrcaTrip(timestamp, agency, transType, coachNumber, fare, newBalance);
+        return new AutoValue_OrcaTrip(timestamp, agency, transType, ftpType, coachNumber, fare, newBalance);
     }
 
     @Override
@@ -263,16 +264,20 @@ public abstract class OrcaTrip extends Trip {
     }
 
     private boolean isLink() {
-        return (getAgency() == OrcaTransitInfo.AGENCY_ST && getCoachNumber() > 10000);
+        return (getAgency() == OrcaTransitInfo.AGENCY_ST &&
+                getFTPType() == OrcaTransitInfo.FTP_TYPE_LINK);
     }
 
     private boolean isSounder() {
-        return (getAgency() == OrcaTransitInfo.AGENCY_ST && getCoachNumber() < 20);
+        return (getAgency() == OrcaTransitInfo.AGENCY_ST &&
+                getFTPType() == OrcaTransitInfo.FTP_TYPE_SOUNDER);
     }
 
     abstract long getAgency();
 
     abstract long getTransType();
+
+    abstract long getFTPType();
 
     abstract long getCoachNumber();
 

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
@@ -98,7 +98,8 @@ public abstract class OrcaTrip extends Trip {
                 | (usefulData[7] >> 4);
 
         long ftpType = ((usefulData[7] & 0xf) << 4) | ((usefulData[8] & 0xf0) >> 4);
-        long coachNumber = ((usefulData[8] & 0xf) << 20) | (usefulData[9] << 12) | (usefulData[10] << 4) | ((usefulData[11] & 0xf0) >> 4);
+        long coachNumber = ((usefulData[8] & 0xf) << 20) | (usefulData[9] << 12)
+                | (usefulData[10] << 4) | ((usefulData[11] & 0xf0) >> 4);
 
         long fare;
         if (usefulData[15] == 0x00 || usefulData[15] == 0xFF) {
@@ -264,13 +265,13 @@ public abstract class OrcaTrip extends Trip {
     }
 
     private boolean isLink() {
-        return (getAgency() == OrcaTransitInfo.AGENCY_ST &&
-                getFTPType() == OrcaTransitInfo.FTP_TYPE_LINK);
+        return (getAgency() == OrcaTransitInfo.AGENCY_ST
+                && getFTPType() == OrcaTransitInfo.FTP_TYPE_LINK);
     }
 
     private boolean isSounder() {
-        return (getAgency() == OrcaTransitInfo.AGENCY_ST &&
-                getFTPType() == OrcaTransitInfo.FTP_TYPE_SOUNDER);
+        return (getAgency() == OrcaTransitInfo.AGENCY_ST
+                && getFTPType() == OrcaTransitInfo.FTP_TYPE_SOUNDER);
     }
 
     abstract long getAgency();

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
@@ -61,14 +61,25 @@ public abstract class OrcaTrip extends Trip {
             .build();
 
     private static Map<Integer, Station> sSounderStations = ImmutableMap.<Integer, Station>builder()
+            .put(1, Station.create("Everett Station", "Everett", "47.9747155", "-122.1996922"))
+            .put(2, Station.create("Edmonds Station", "Edmonds", "47.8109946","-122.3864407"))
             .put(3, Station.create("King Street Station", "King Street", "47.598445", "-122.330161"))
+            .put(4, Station.create("Tuwkila Station", "Tukwila", "47.4603283", "-122.2421456"))
             .put(5, Station.create("Kent Station", "Kent", "47.384257", "-122.233151"))
+            .put(6, Station.create("Auburn Station", "Auburn", "47.3065191", "-122.2343063"))
+            .put(7, Station.create("Sumner Station", "Sumner", "47.2016577", "-122.2467547"))
+            .put(8, Station.create("Puyallup Station", "Puyallup", "47.1926213", "-122.2977392"))
+            .put(9, Station.create("Tacoma Dome Station", "Tacoma Dome", "47.2408695", "-122.4278904"))
+            .put(0x1e01, Station.create("Mukilteo Station", "Mukilteo", "47.9491683", "-122.3010919"))
+            .put(0x1e02, Station.create("Lakewood Station", "Lakewood", "47.1529884", "-122.5015344"))
+            .put(0x37e5, Station.create("South Tacoma Station", "South Tacoma", "47.2038608", "-122.4877278"))
             .build();
 
     private static Map<Integer, Station> sWSFTerminals = ImmutableMap.<Integer, Station>builder()
             .put(10101, Station.create("Seattle Terminal", "Seattle", "47.602722", "-122.338512"))
             .put(10103, Station.create("Bainbridge Island Terminal", "Bainbridge", "47.62362", "-122.51082"))
             .put(10104, Station.create("Fauntleroy Terminal", "Seattle", "47.5231", "-122.39602"))
+            .put(10115, Station.create("Anacortes Terminal", "Anacortes", "48.5065077", "-122.680434"))
             .build();
 
     @NonNull


### PR DESCRIPTION
This PR fixes a few issues with ORCA cards:

1. It now parses the serial number of U-PASSes correctly. The CSN is actually four bytes long, and is already parsed correctly in parseIdentity.
2. It adds more stops for the Sounder, and one additional terminal for the ferries.
3. It (probably) supports coach IDs above 65535. Apparently Sound Transit actually has some of these.
4. The Fare Transaction Processor type is parsed, which is now used to differentiate between ST buses/Link/Sounder instead of relying on hardcoded "coach" IDs.

I believe FTP type 0xFA is used for KCM RapidRide stops, but I don't have any stop IDs yet.