### PR TITLE
Add ORCA station info for BRT and Streetcar

### DIFF
--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTransitInfo.java
@@ -53,6 +53,8 @@ public abstract class OrcaTransitInfo extends TransitInfo {
     static final int FTP_TYPE_SOUNDER = 0x09;
     static final int FTP_TYPE_BUS = 0x80;
     static final int FTP_TYPE_LINK = 0xFB;
+    static final int FTP_TYPE_STREETCAR = 0xF9;
+    static final int FTP_TYPE_BRT = 0xFA; //May also apply to future hardwired bus readers
 
     @NonNull
     @Override

--- a/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
+++ b/farebot-transit-orca/src/main/java/com/codebutler/farebot/transit/orca/OrcaTrip.java
@@ -82,6 +82,332 @@ public abstract class OrcaTrip extends Trip {
             .put(10115, Station.create("Anacortes Terminal", "Anacortes", "48.5065077", "-122.680434"))
             .build();
 
+    private static final Map<Integer, Station> BRT_STATIONS = ImmutableMap.<Integer, Station>builder()
+            .put(8101, Station.create("Bellevue Transit Ctr", "Bell TC", "47.6155475013397", "-122.195381419512"))
+            .put(8102, Station.create("NE 8th & 124th NE EB", "8th & 124th EB", "47.6174257912468", "-122.1759606331"))
+            .put(8103, Station.create("NE 8th & 140th NE EB", "8th & 140th EB", "47.617073832799",
+                "-122.153093218803")) //Renamed from 104th
+            .put(8104, Station.create("156th NE & NE 10th NB", "156th & 10th NB", "47.6183213583588",
+                "-122.132316827774"))
+            .put(8105, Station.create("156th NE & NE 15th NB", "156th & 15th NB", "47.6241102105962",
+                "-122.132300734519"))
+            .put(8106, Station.create("NE 24th & Bel-Red WB", "24th & Bel-Red WB", "47.631649", "-122.134445"))
+            .put(8107, Station.create("156th NE at OTC NB", "156th @ OTC NB", "47.643988463442", "-122.132188081741"))
+            .put(8108, Station.create("148th NE & NE 51st NB", "148th & 51st NB", "47.6557368980797",
+                "-122.143093943595"))
+            .put(8109, Station.create("Redmond Transit Ctr", "Redmond TC", "47.6766509387843", "-122.124935003843"))
+            .put(8110, Station.create("148th NE & NE 87th SB", "148th & 87th SB", "47.6807680373983",
+                "-122.145234346389"))
+            .put(8111, Station.create("148th NE & NE Old Redmond Rd SB", "148th & Old Redmond SB", "47.667126850434",
+                "-122.143295109272"))
+            .put(8112, Station.create("148th NE & NE 51st SB", "148th & 51st SB", "47.6546637118338",
+                "-122.143464088439"))
+            .put(8113, Station.create("156th NE at OTC SB", "156th @ OTC SB", "47.6447799666965", "-122.132397294044"))
+            .put(8114, Station.create("156th NE & NE 24th SB", "156th & 24th SB", "47.630863663919",
+                "-122.132450938224"))
+            .put(8115, Station.create("156th NE & NE 15th SB", "156th & 15th SB", "47.6241752908626",
+                "-122.132493853569"))
+            .put(8116, Station.create("156th NE & NE 10th SB", "156th & 10th SB", "47.618153215345",
+                "-122.132515311241"))
+            .put(8117, Station.create("NE 8th & 140th NE WB", "8th & 140th WB", "47.6172835638151",
+                "-122.154402136802"))
+            .put(8118, Station.create("NE 8th & 124th NE WB", "8th & 124th WB", "47.6172732395513", "-122.17461282307"))
+            .put(8130, Station.create("SW Avalon & SW Bradford SB", "Avalon & Bradford SB", "47.5688667", "-122.37085"))
+            .put(8131, Station.create("SW Avalon & SW Yancy NB", "Avalon & Yancy NB", "47.5678825", "-122.370674"))
+            .put(8132, Station.create("35th SW & SW Avalon SB", "35th & Avalon SB", "47.56354143475",
+                "-122.376263737678"))
+            .put(8133, Station.create("35th SW & SW Avalon NB", "35th & Avalon NB", "47.5637097533135",
+                "-122.376100122928"))
+            .put(8134, Station.create("SW Alaska & Fauntleroy SW WB", "Alaska & Fauntleroy WB", "47.5611541487228",
+                "-122.380509674549"))
+            .put(8135, Station.create("SW Alaska & Fauntleroy SW EB", "Alaska & Fauntleroy EB", "47.5610165913989",
+                "-122.380869090557"))
+            .put(8136, Station.create("SW Alaska & California Ave WB", "Alaska & California WB", "47.5612030176851",
+                "-122.387078404426"))
+            .put(8137, Station.create("SW Alaska & California Ave EB", "Alaska & California EB", "47.5610546006955",
+                "-122.386871874332"))
+            .put(8138, Station.create("California SW & SW Findlay SB", "California & Findlay SB", "47.5518645981645",
+                "-122.38714814186"))
+            .put(8139, Station.create("California SW & SW Findlay NB", "California & Findlay NB", "47.5523696647784",
+                "-122.386933565139"))
+            .put(8140, Station.create("Fauntleroy SW & California SW WB", "Fauntleroy & California WB",
+                "47.5448655755196", "-122.387681901454"))
+            .put(8141, Station.create("California SW & Fauntleroy SW NB", "California & Fauntleroy NB",
+                "47.545310962797", "-122.387107908725"))
+            .put(8142, Station.create("Fauntleroy Ferry SB", "Fauntleroy Ferry SB", "47.5230070769314",
+                "-122.393074482679"))
+            .put(8143, Station.create("Fauntleroy Ferry NB", "Fauntleroy Ferry NB", "47.5231782426048",
+                "-122.392898797988"))
+            .put(8144, Station.create("SW Barton & 35th Ave SW WB", "SW Barton & 35th WB", "47.5211387084209",
+                "-122.377245426177"))
+            .put(8145, Station.create("SW Barton & 26th Ave SW EB", "SW Barton & 26th EB", "47.5209648190673",
+                "-122.367358803749"))
+            .put(8146, Station.create("3rd & Pike SB", "3rd & Pike SB", "47.609081", "-122.337327399999"))
+            .put(8147, Station.create("3rd & Pike NB", "3rd & Pike NB", "47.6102046770867", "-122.33808517456"))
+            .put(8148, Station.create("3rd & Seneca SB", "3rd & Seneca SB", "47.6064306874019", "-122.334909439086"))
+            .put(8149, Station.create("3rd & Seneca NB", "3rd & Seneca NB", "47.6070220300827", "-122.335150837898"))
+            .put(8150, Station.create("Seneca & 2nd EB", "Seneca & 2nd EB", "47.6068773597082", "-122.335641682147"))
+            .put(8151, Station.create("3rd & Columbia SB", "3rd & Columbia SB", "47.6037994026769", "-122.3325034976"))
+            .put(8152, Station.create("3rd & Columbia NB", "3rd & Columbia NB", "47.60419184323", "-122.332589328289"))
+            .put(8153, Station.create("3rd & Marion SB", "3rd & Marion SB", "47.6044233275213", "-122.333064079284"))
+            .put(8154, Station.create("Prefontaine & Yesler NB", "Prefontaine & Yesler NB", "47.6015893829318",
+                "-122.329794466495"))
+            .put(8160, Station.create("15th NW & NW 85 NB", "15th & 85 NB", "47.6911774", "-122.376709"))
+            .put(8161, Station.create("15th NW & NW 85 SB", "15th & 85 SB", "47.6901610986643", "-122.376902103424"))
+            .put(8162, Station.create("15th NW & NW 70 SB", "15th & 70 SB", "47.6790380273793", "-122.376880645751"))
+            .put(8163, Station.create("15th NW & NW 65 NB", "15th & 65 NB", "47.6798759517131", "-122.376671433448"))
+            .put(8164, Station.create("15th NW & NW 65 SB", "15th & 65 SB", "47.6761413059686", "-122.376821637153"))
+            .put(8165, Station.create("15th NW & NW 60 SB", "15th & 60 SB", "47.6724389029691", "-122.37631201744"))
+            .put(8166, Station.create("15th NW & NW Market NB", "15th & Market NB", "47.6684725252118",
+                "-122.376118898391"))
+            .put(8167, Station.create("15th NW & NW Market SB", "15th & Market SB", "47.6689096362649",
+                "-122.37631201744"))
+            .put(8168, Station.create("15th NW & NW Leary NB", "15th & Leary NB", "47.6634183885893",
+                "-122.376043796539"))
+            .put(8169, Station.create("15th NW & NW Leary SB", "15th & Leary SB", "47.663143811041",
+                "-122.376483678817"))
+            .put(8170, Station.create("15th W & W Dravus NB", "15th & Dravus NB", "47.6491601240274",
+                "-122.376097440719"))
+            .put(8171, Station.create("15th W & W Dravus SB", "15th & Dravus SB", "47.6481373973892",
+                "-122.376875281333"))
+            .put(8172, Station.create("Elliot W & W Prospect NB", "Elliot & Prospect NB", "47.6290163123735",
+                "-122.371414303779"))
+            .put(8173, Station.create("3rd Ave & Vine NB", "3rd & Vine NB", "47.6168767571982", "-122.348282933235"))
+            .put(8174, Station.create("3rd Ave & Cedar SB", "3rd & Cedar SB", "47.6168821813073", "-122.348701357841"))
+            .put(8175, Station.create("3rd Ave & Bell NB", "3rd & Bell NB", "47.6149855168781", "-122.34508305788"))
+            .put(8176, Station.create("3rd Ave & Bell SB", "3rd & Bell SB", "47.614444891634", "-122.344514429569"))
+            .put(8177, Station.create("3rd Ave & Virginia NB", "3rd & Virginia NB", "47.6128229823651",
+                "-122.341424524784"))
+            .put(8178, Station.create("3rd Ave & Virginia SB", "3rd & Virginia SB", "47.6124450720877",
+                "-122.341145575046"))
+            .put(8179, Station.create("W Mercer & 3rd W EB", "Mercer & 3rd EB", "47.6245684242042",
+                "-122.360917254804"))
+            .put(8180, Station.create("Mercer & Queen Anne WB", "Mercer & Queen Anne WB", "47.6246489281384",
+                "-122.356552183628"))
+            .put(8181, Station.create("Queen Anne & Mercer SB", "Queen Anne & Mercer SB", "47.6243063550421",
+                "-122.356819063425"))
+            .put(8182, Station.create("1st N & Republican NB", "1st & Republican NB", "47.6231882314514",
+                "-122.355315685272"))
+            .put(8183, Station.create("Queen Anne & W John SB", "Queen Anne & John SB", "47.6192144960556",
+                "-122.356849908828"))
+            .put(8184, Station.create("1st N & Denny NB", "1st & Denny NB", "47.6188766663707", "-122.355371862061"))
+            .put(8185, Station.create("15 NW & NW 80 SB", "15 & 80 SB", "47.6860624506418", "-122.376896739006"))
+            .put(8186, Station.create("15 NW & NW 75 SB", "15 & 75 SB", "47.683072220525", "-122.376928925514"))
+            .put(8187, Station.create("15 W & W Emerson SB", "15 & Emerson SB", "47.653473", "-122.376328"))
+            .put(8188, Station.create("15 W & W Armory SB", "15 & Armory SB", "47.637283696861", "-122.376408576965"))
+            .put(8189, Station.create("W Mercer & 3rd WB", "Mercer & 3rd WB", "47.6246679096956", "-122.361153513193"))
+            .put(8190, Station.create("Burien TC Bay 6 SB", "Burien TC Bay 6", "47.4694099", "-122.337318"))
+            .put(8191, Station.create("Tukwila International Blvd Station", "TIBS", "47.464098",
+            "-122.288176099999")) //Renamed from Tukwila LLR/S154 WB
+            .put(8192, Station.create("Southcenter & 62nd Ave S EB", "Southcenter & 62nd EB", "47.462814",
+                "-122.257118"))
+            .put(8193, Station.create("Andover & Baker SB", "Andover & Baker SB", "47.457881071895",
+                "-122.254480719566"))
+            .put(8194, Station.create("Tukwila Sounder Station", "Tukwila Sounder Station", "47.4604308295467",
+            "-122.241101861")) //Renamed from Tukwila Comm Rail/Bay EB, TODO: Compare to 8200
+            .put(8195, Station.create("Rainier & S 7th NB", "Rainier & 7th NB", "47.4741712774955",
+                "-122.215502858161"))
+            .put(8196, Station.create("Renton TC Bay 2", "Renton TC Bay 2", "47.480546", "-122.2085766"))
+            .put(8197, Station.create("Park Ave N & Garden Ave N WB", "Park & Garden WB", "47.5005871",
+            "-122.2012435")) //Renamed from N 10/Garden Ave N WB
+            .put(8198, Station.create("Renton TC Bay 3", "Renton TC Bay 3", "47.480546", "-122.2085766"))
+            .put(8199, Station.create("S 7th & Rainier WB", "7th & Rainier WB", "47.4738730438368",
+                "-122.217086702585"))
+            .put(8200, Station.create("Tukwila Sounder Station", "Tukwila Sounder Station", "47.4607898893259",
+            "-122.24082827568")) //Renamed from Tukwila Rail/Bat WB, TODO: Compare to 8194
+            .put(8201, Station.create("Andover & Baker NB", "Andover & Baker NB", "47.4587152878659",
+                "-122.254276871681"))
+            .put(8220, Station.create("Aurora Village TC", "Aurora Village TC", "47.7745224987306",
+                "-122.341010123491"))
+            .put(8221, Station.create("Aurora N & N 192 SB", "Aurora & 192 SB", "47.7672855442468",
+            "-122.346104979515")) //Renamed from Shoreline P&R
+            .put(8222, Station.create("Aurora N & N 185 SB", "Aurora & 185 SB", "47.7628503952128",
+                "-122.346185445785"))
+            .put(8223, Station.create("Aurora N & N 175 SB", "Aurora & 175 SB", "47.7552989544991",
+                "-122.345858216285"))
+            .put(8224, Station.create("Aurora N & N 160 SB", "Aurora & 160 SB", "47.7484425665415",
+                "-122.345691919326"))
+            .put(8225, Station.create("Aurora N & N 145 SB", "Aurora & 145 SB", "47.7335725349705",
+                "-122.345268130302"))
+            .put(8226, Station.create("Aurora N & N 135 SB", "Aurora & 135 SB", "47.7264318233991",
+                "-122.345117926597"))
+            .put(8227, Station.create("Aurora N & N 130 SB", "Aurora & 130 SB", "47.7229639493678",
+                "-122.345080375671"))
+            .put(8228, Station.create("Aurora N & N 125 SB", "Aurora & 125 SB", "47.7199036564968",
+                "-122.345048189163"))
+            .put(8229, Station.create("Aurora N & N 115 SB", "Aurora & 115 SB", "47.7118803608749",
+                "-122.344914078712"))
+            .put(8230, Station.create("Aurora N & N 105 SB", "Aurora & 105 SB", "47.7047303996993",
+                "-122.344817118649"))
+            .put(8231, Station.create("Aurora N & N 100 SB", "Aurora & 100 SB", "47.7010904555273",
+                "-122.344812154769"))
+            .put(8232, Station.create("Aurora N & N 95 SB", "Aurora & 95 SB", "47.6974945275512", "-122.344704866409"))
+            .put(8233, Station.create("Aurora N & N 90 SB", "Aurora & 90 SB", "47.6939886200535", "-122.345026731491"))
+            .put(8234, Station.create("Aurora N & N 85 SB", "Aurora & 85 SB", "47.6904969207454", "-122.344737052917"))
+            .put(8235, Station.create("Aurora N & N 76 SB", "Aurora & 76 SB", "47.6841520456182", "-122.344651222229"))
+            .put(8236, Station.create("Aurora N & N 65 SB", "Aurora & 65 SB", "47.6763363521107", "-122.346984744071"))
+            .put(8237, Station.create("Aurora N & N 46 SB", "Aurora & 46 SB", "47.6616733514361", "-122.347488999366"))
+            //.put(8238, Station.create("Aurora N & Harrison SB", "Aurora & Harrison SB", "", ""))
+            .put(8239, Station.create("Wall St & 5th Ave WB", "Wall & 5th WB", "47.6175626", "-122.3451438"))
+            .put(8240, Station.create("Aurora N & Denny NB", "Aurora & Denny NB", "47.6180899355761",
+                "-122.343460321426"))
+            //.put(8241, Station.create("Aurora N & Harrison NB", "Aurora & Harrison NB", "", ""))
+            .put(8242, Station.create("Aurora N & N 46 NB", "Aurora & 46 NB", "47.6616878033291", "-122.347161769866"))
+            .put(8243, Station.create("Aurora N & N 85 NB", "Aurora & 85 NB", "47.6908941268671", "-122.344361543655"))
+            .put(8244, Station.create("Aurora N & N 91 NB", "Aurora & 91 NB", "47.6946927089615", "-122.344409823417"))
+            .put(8245, Station.create("Aurora N & N 100 NB", "Aurora & 100 NB", "47.7016753119282",
+                "-122.344490289688"))
+            .put(8246, Station.create("Aurora N & N Northgate Way NB", "Aurora & NGate NB", "47.7053539804587",
+                "-122.344543933868"))
+            .put(8247, Station.create("Aurora N & N 130 NB", "Aurora & 130 NB", "47.7234619517184",
+                "-122.344881892204"))
+            .put(8248, Station.create("Aurora N & N 135 NB", "Aurora & 135 NB", "47.7273014621554",
+                "-122.344924807548"))
+            .put(8249, Station.create("Aurora N & N 145 NB", "Aurora & 145 NB", "47.7349255155068",
+                "-122.344914078712"))
+            .put(8250, Station.create("Aurora N & N 160 NB", "Aurora & 160 NB", "47.7490665676696",
+                "-122.345337867736"))
+            .put(8251, Station.create("Aurora N & N 185 NB", "Aurora & 185 NB", "47.7636761548606",
+                "-122.345804572105"))
+            .put(8301, Station.create("Blanchard & 6th EB", "Blanchard & 6th EB", "47.615844358198",
+                "-122.340904176235"))
+            .put(8302, Station.create("Westlake & 9th NB", "Westlake & 9th NB", "47.6180953595593", "-122.33830243349"))
+            .put(8303, Station.create("Valley & Fairview SB", "Valley & Fairview SB", "47.6260390829929",
+                "-122.333831191062"))
+            .put(8304, Station.create("Westlake & Mercer SB", "Westlake & Mercer SB", "47.624065919813",
+                "-122.33858205378"))
+            .put(8305, Station.create("Westlake & Harrison SB", "Westlake & Harrison SB", "47.6214526971832",
+                "-122.338578701019"))
+            .put(8306, Station.create("Westlake & 9th SB", "Westlake & 9th SB", "47.6179615678097", "-122.33851969242"))
+            //.put(8307, Station.create("Lenora & 7th WB", "Lenora & 7th WB", "", ""))
+            .put(13161, Station.create("238th St NB", "238th St NB", "47.7835264994018", "-122.343159914016"))
+            .put(13162, Station.create("238th St SB", "238th St SB", "47.7828416337193", "-122.344018220901"))
+            .put(13163, Station.create("Gateway at 216th NB", "Gateway at 216th NB", "47.8035350116184",
+                "-122.328729629516"))
+            .put(13164, Station.create("216th St SB", "216th St SB", "47.8028468063936", "-122.329609394073"))
+            .put(13165, Station.create("Heron at 200th NB", "Heron at 200th NB", "47.8178339250236",
+                "-122.317839860916"))
+            .put(13166, Station.create("Crossroads at 196 SB", "Crossroads at 196 SB", "47.8208344317007",
+                "-122.315602898597"))
+            .put(13167, Station.create("Cherry Hill & 176 NB", "Cherry Hill & 176 NB", "47.8396277775522",
+                "-122.298973202705"))
+            .put(13168, Station.create("International 174 SB", "International 174 SB", "47.8408231764694",
+                "-122.298310697078"))
+            .put(13169, Station.create("148th St NB", "148th St NB", "47.8647739557922", "-122.281265258789"))
+            .put(13170, Station.create("148th St SB", "148th St SB", "47.8638022450146", "-122.282488346099"))
+            .put(13171, Station.create("Lincoln Way NB", "Lincoln Way NB", "47.8733566098851", "-122.273218631744"))
+            .put(13172, Station.create("Lincoln Way SB", "Lincoln Way SB", "47.8739467275835", "-122.273030877113"))
+            .put(13173, Station.create("Airport Rd NB", "Airport Rd NB", "", ""))
+            .put(13174, Station.create("Airport Rd SB", "Airport Rd SB", "", ""))
+            .put(13175, Station.create("4th Ave NB", "4th Ave NB", "47.9097046662584", "-122.239256501197"))
+            .put(13176, Station.create("4th Ave SB", "4th Ave SB", "47.9099815401481", "-122.239401340484"))
+            .put(13177, Station.create("Casino Rd NB", "Casino Rd NB", "47.9211703205365", "-122.22852230072"))
+            .put(13178, Station.create("Casino Rd SB", "Casino Rd SB", "47.9212997395726", "-122.228833436965"))
+            .put(13179, Station.create("50th St NB", "50th St NB", "47.9520886693373", "-122.213426828384"))
+            .put(13180, Station.create("50th St SB", "50th St SB", "47.9516790852515", "-122.213920354843"))
+            .put(13181, Station.create("40th St NB", "40th St NB", "47.9649134757321", "-122.210680246353"))
+            .put(13182, Station.create("41st St SB", "41st St SB", "47.9628803994514", "-122.210948467254"))
+            .put(13183, Station.create("Colby Ave EB", "Colby Ave EB", "47.9764710352963", "-122.207987308502"))
+            .put(13184, Station.create("Wetmore Ave WB", "Wetmore Ave WB", "47.9766793205954", "-122.206785678863"))
+            .put(13185, Station.create("Aurora Village TC", "Aurora Village TC", "47.7742926694779",
+                "-122.34112009406"))
+            .put(13186, Station.create("Everett Station Bay 1", "Everett Station", "47.9747867778208",
+                "-122.197498146052"))
+            .put(13187, Station.create("Peck Drive SB", "Peck Drive SB", "47.9414096794754", "-122.217804193496"))
+            .put(13188, Station.create("Merrill Creek Test & Training Station", "Merrill Creek", "47.9339669026849",
+                "-122.251898540424"))
+            .put(13189, Station.create("Madison Drive NB", "Madison Drive NB", "47.9365293796851", "-122.218716144561"))
+            .put(13190, Station.create("112th SB", "112th SB", "47.8961108540724", "-122.252415418624"))
+            .put(13191, Station.create("112th NB", "112th NB", "47.8968301928371", "-122.251262068748"))
+            .put(13206, Station.create("Tukwila Light Rail Station Bay 1", "TIBS Bay 1", "47.464098",
+                "-122.288176099999"))
+            .put(13207, Station.create("S 176th St SB", "176th St SB", "47.4453208950317", "-122.296457290649"))
+            .put(13208, Station.create("S 176th St NB", "176th St NB", "47.4456165697685", "-122.296097874641"))
+            .put(13209, Station.create("S 182nd St SB", "182nd St SB", "47.439793466891", "-122.296183705329"))
+            .put(13210, Station.create("S 180nd St NB", "180nd St NB", "47.442456573361", "-122.295926213264"))
+            .put(13211, Station.create("S 188th St SB", "188th St SB", "47.4340205212797", "-122.295679450035"))
+            .put(13212, Station.create("S 188th St NB", "188th St NB", "47.4349821180936", "-122.295405864715"))
+            .put(13213, Station.create("S 200th St SB", "200th St SB", "47.4223783629138", "-122.296580672264"))
+            .put(13214, Station.create("S 200th St NB", "200th St NB", "47.423274842546", "-122.296092510223"))
+            .put(13215, Station.create("S 208th ST SB", "208th ST SB", "47.4148066750236", "-122.297546267509"))
+            .put(13216, Station.create("S 208th St NB", "208th St NB", "47.4157722528427", "-122.297047376632"))
+            .put(13217, Station.create("S 216th St SB", "216th St SB", "47.4077566944469", "-122.2984957695"))
+            .put(13218, Station.create("S 216th St NB", "216th St NB", "47.4088458364992", "-122.297943234443"))
+            .put(13219, Station.create("Kent Des Moines SB", "Kent Des Moines SB", "47.3926225507716",
+                "-122.29517519474"))
+            .put(13220, Station.create("Kent Des Moines NB", "Kent Des Moines NB", "47.3945399764362",
+                "-122.294644117355"))
+            .put(13221, Station.create("S 240th St SB", "240th St SB", "47.3857911548532", "-122.296838164329"))
+            .put(13222, Station.create("S 240th St NB", "240th St NB", "47.3862742119375", "-122.296333909034"))
+            .put(13223, Station.create("S 260th St SB", "260th St SB", "47.3680166617334", "-122.304321527481"))
+            .put(13224, Station.create("S 260th St NB", "260th St NB", "47.3694735745929", "-122.303146719932"))
+            .put(13225, Station.create("S 272 ST SB", "272 ST SB", "47.3573265591089", "-122.309975624084"))
+            .put(13226, Station.create("S 272nd St NB", "272nd St NB", "47.3588746142789", "-122.308688163757"))
+            .put(13227, Station.create("S 288th St SB", "288th St SB", "47.3429776333081", "-122.312496900558"))
+            .put(13228, Station.create("S 288th St NB", "288th St NB", "47.3437736865565", "-122.312081158161"))
+            .put(13229, Station.create("S 312th St SB", "312th St SB", "47.3220905786881", "-122.313564419746"))
+            .put(13230, Station.create("S 312th St NB", "312th St NB", "47.322810583296", "-122.313183546066"))
+            //.put(13251, Station.create("Hwy 99 at 204th Street SB", "Hwy 99 at 204th Street SB", "", ""))
+            .put(13838, Station.create("Federal Way TC Bay 7", "FWTC Bay 7", "47.3175545", "-122.304787"))
+            .put(13839, Station.create("Z Line (Test Location)", "Z Line", "47.4955968",
+            "-122.285024799999")) //No idea where this actually is
+            .build();
+
+    private static final Map<Integer, Station> SEATTLE_STREETCAR_STATIONS = ImmutableMap.<Integer, Station>builder()
+            .put(9056, Station.create("14th Ave S & Washington", "14th & Washington", "47.6005639165279",
+                "-122.314181327819"))
+            .put(9065, Station.create("Broadway & E Denny NB", "Broadway & Denny NB", "47.6181568313295",
+                "-122.320747375488"))
+            .put(9066, Station.create("Broadway & E Denny SB", "Broadway & Denny SB", "47.6180158077495",
+                "-122.320980727672"))
+            //.put(9067, Station.create("Broadway & Harrison NB", "Broadway & Harrison NB", "", ""))
+            //.put(9068, Station.create("Broadway & Harrison SB", "Broadway & Harrison SB", "", ""))
+            .put(9061, Station.create("Broadway & Marion NB", "Broadway & Marion NB", "47.6098502555259",
+                "-122.320717871189"))
+            .put(9062, Station.create("Broadway & Marion SB", "Broadway & Marion SB", "47.6098086650832",
+                "-122.320913672447"))
+            .put(9064, Station.create("Broadway & Pine NB", "Broadway & Pine NB", "47.6150723056943",
+                "-122.320758104324"))
+            .put(9063, Station.create("Broadway & Pine SB", "Broadway & Pine SB", "47.6161933149567",
+            "-122.320924401283")) //Renamed from Pike
+            //.put(9070, Station.create("Broadway & Prospect", "Broadway & Prospect", "", ""))
+            //.put(9069, Station.create("Broadway & Roy", "Broadway & Roy", "", ""))
+            .put(9059, Station.create("Broadway & Terrace NB", "Broadway & Terrace NB", "47.6054649941559",
+                "-122.320712506771"))
+            .put(9060, Station.create("Broadway & Terrace SB", "Broadway & Terrace SB", "47.6049785239516",
+                "-122.320937812328"))
+            .put(9057, Station.create("E Yesler Wy & Broadway EB", "Yesler & Broadway EB", "47.6016327884738",
+                "-122.32006072998"))
+            .put(9058, Station.create("E Yesler Wy & Broadway WB", "Yesler & Broadway WB", "47.6017431107308",
+                "-122.320216298103"))
+            .put(9007, Station.create("Fairview & Aloha", "Fairview & Aloha", "47.627573814398",
+            "-122.332401573657")) //Renamed from Fairview & Campus
+            .put(9006, Station.create("Lake Union Park", "Lake Union Park", "47.6259030928503", "-122.336444975041"))
+            .put(9001, Station.create("McGraw Square", "McGraw Square", "47.6129802934938", "-122.337363660335"))
+            .put(9051, Station.create("Occidental S & S Jackson", "Occidental & Jackson", "47.5991973", "-122.3332461"))
+            .put(9055, Station.create("S Jackson & 12th Ave S", "Jackson & 12th Ave", "47.599210161578",
+            "-122.315737009048")) //Renamed from 13th
+            .put(9052, Station.create("S Jackson & 5th Ave S EB", "Jackson & 5th Ave EB", "47.5992065442833",
+                "-122.326776981353"))
+            .put(9053, Station.create("S Jackson & 5th Ave S WB", "Jackson & 5th Ave WB", "47.5992065442833",
+                "-122.326776981353"))
+            .put(9054, Station.create("S Jackson & 7th Ave S", "Jackson & 7th Ave", "47.5992002140171",
+                "-122.323275357484"))
+            .put(9005, Station.create("Terry & Republican NB", "Terry & Republican NB", "47.6234169199518",
+            "-122.337044477462")) //Renamed from Terry & Mercer NB
+            .put(9004, Station.create("Terry & Thomas NB", "Terry & Thomas NB", "47.6213677268386",
+                "-122.337264418601"))
+            .put(9002, Station.create("Westlake & 7th NB", "Westlake & 7th NB", "47.6154700859254",
+                "-122.337763309478"))
+            .put(9003, Station.create("Westlake & Denny NB", "Westlake & Denny NB", "47.6180953595593",
+                "-122.33830243349"))
+            .put(9008, Station.create("Westlake & Mercer SB", "Westlake & Mercer SB", "47.624065919813",
+                "-122.33858205378"))
+            .put(9010, Station.create("Westlake & 9th SB", "Westlake & 9th SB", "47.6179615678097", "-122.33851969242"))
+            .put(9009, Station.create("Westlake & Thomas SB", "Westlake & Thomas SB", "47.6214526971832",
+                "-122.338578701019"))
+            .build();
+
     @NonNull
     static OrcaTrip create(@NonNull DesfireRecord record) {
         byte[] useData = record.getData().bytes();
@@ -203,6 +529,10 @@ public abstract class OrcaTrip extends Trip {
             return sSounderStations.get((int) getCoachNumber());
         } else if (getAgency() == OrcaTransitInfo.AGENCY_WSF) {
             return sWSFTerminals.get((int) getCoachNumber());
+        } else if (isSeattleStreetcar()) {
+            return SEATTLE_STREETCAR_STATIONS.get((int) getCoachNumber());
+        } else if (isRapidRide() || isSwift()) {
+            return BRT_STATIONS.get((int) getCoachNumber());
         }
         return null;
     }
@@ -232,6 +562,22 @@ public abstract class OrcaTrip extends Trip {
                 return resources.getString(R.string.transit_orca_station_unknown_terminal,
                         Integer.toString(terminalNumber));
             }
+        } else if (isRapidRide() || isSwift()) {
+            int stationNumber = (int) getCoachNumber();
+            if (BRT_STATIONS.containsKey(stationNumber)) {
+                return BRT_STATIONS.get(stationNumber).getStationName();
+            } else {
+                return resources.getString(R.string.transit_orca_station_unknown_station,
+                        Integer.toString(stationNumber));
+            }
+        } else if (isSeattleStreetcar()) {
+            int stationNumber = (int) getCoachNumber();
+            if (SEATTLE_STREETCAR_STATIONS.containsKey(stationNumber)) {
+                return SEATTLE_STREETCAR_STATIONS.get(stationNumber).getStationName();
+            } else {
+                return resources.getString(R.string.transit_orca_station_unknown_station,
+                        Integer.toString(stationNumber));
+            }
         } else {
             return resources.getString(R.string.transit_orca_station_coach,
                     Long.toString(getCoachNumber()));
@@ -258,6 +604,8 @@ public abstract class OrcaTrip extends Trip {
             return Mode.TRAIN;
         } else if (getAgency() == OrcaTransitInfo.AGENCY_WSF) {
             return Mode.FERRY;
+        } else if (isSeattleStreetcar()) {
+            return Mode.TRAM;
         } else {
             return Mode.BUS;
         }
@@ -276,6 +624,20 @@ public abstract class OrcaTrip extends Trip {
     private boolean isSounder() {
         return (getAgency() == OrcaTransitInfo.AGENCY_ST
                 && getFTPType() == OrcaTransitInfo.FTP_TYPE_SOUNDER);
+    }
+
+    private boolean isRapidRide() {
+        return (getAgency() == OrcaTransitInfo.AGENCY_KCM
+                && getFTPType() == OrcaTransitInfo.FTP_TYPE_BRT);
+    }
+
+    private boolean isSeattleStreetcar() {
+        return getFTPType() == OrcaTransitInfo.FTP_TYPE_STREETCAR; //TODO: Find agency ID
+    }
+
+    private boolean isSwift() {
+        return (getAgency() == OrcaTransitInfo.AGENCY_CT
+                && getFTPType() == OrcaTransitInfo.FTP_TYPE_BRT);
     }
 
     abstract long getAgency();


### PR DESCRIPTION
After a long battle with the various agencie's public disclosure offices pointing fingers towards each other I was able to source a giant list of location IDs for all hardwired readers not directly controlled by ST (read: the non-Link and non-Sounder ones).

I took a few creative liberties renaming some stations to closer match how they show in the GTFS, but it was a long arduous process coupled with getting lat/lon pairs for each so the list is by no means preferrable.  I've also guessed at where many of them were, as their original names were occasionally nonsensical and there's only about 4 on this list I can actually match based on the trip history of my own cards.

There are four "future" streetcar stations that I've left in but commented out, plus a few BRT readers that point to locations that aren't currently, and may never have been active.

Lastly, I'd like to note that the `FA` FTP type I've denoted as BRT as all of these are currently at BRT stations.  However KCM has plans to install more of these along 3rd Ave downtown at non-RapidRide stops, so this might get re-used, at which point I've no idea what to use for [the second hard problem](https://twitter.com/secretGeek/status/7269997868).


----
cc @supersat 