### PR TITLE
fix: use composite key for CardInfo in HelpScreen grid

### DIFF
--- a/app/src/commonMain/kotlin/com/codebutler/farebot/shared/ui/screen/HelpScreen.kt
+++ b/app/src/commonMain/kotlin/com/codebutler/farebot/shared/ui/screen/HelpScreen.kt
@@ -280,14 +280,14 @@ fun ExploreContent(
                                 .padding(horizontal = 12.dp, vertical = 8.dp),
                     )
                 }
-                items(cards, key = { it.nameRes.key }) { card ->
+                items(cards, key = { it.uniqueKey }) { card ->
                     CardImageTile(
                         card = card,
                         cardName = cardNames[card.nameRes.key] ?: "",
                         isSupported = card.cardType in supportedCardTypes,
                         isKeysRequired = card.keysRequired && card.keyBundle !in loadedKeyBundles,
                         onTap = {
-                            selectedCardKey = card.nameRes.key
+                            selectedCardKey = card.uniqueKey
                         },
                     )
                 }
@@ -337,7 +337,7 @@ fun ExploreContent(
     // Bottom sheet for selected card details
     val selectedCard =
         selectedCardKey?.let { key ->
-            supportedCards.find { it.nameRes.key == key }
+            supportedCards.find { it.uniqueKey == key }
         }
     if (selectedCard != null) {
         ModalBottomSheet(

--- a/transit/src/commonMain/kotlin/com/codebutler/farebot/transit/CardInfo.kt
+++ b/transit/src/commonMain/kotlin/com/codebutler/farebot/transit/CardInfo.kt
@@ -41,4 +41,6 @@ data class CardInfo(
     /** Brand color as 0xRRGGBB (no alpha). Null if unknown — UI will use a theme-appropriate fallback. */
     val brandColor: Int?,
     val credits: List<String> = emptyList(),
-)
+) {
+    val uniqueKey: String get() = "${nameRes.key}:${cardType.name}"
+}


### PR DESCRIPTION
## Summary
- Multiple `CardInfo` entries can share the same `nameRes` (e.g., Troika registers both MifareClassic and MifareUltralight variants with `Res.string.card_name_troika`)
- The HelpScreen `LazyVerticalGrid` used `nameRes.key` alone as the item key, causing a duplicate key crash when scrolling
- Added `CardInfo.uniqueKey` computed property (`"${nameRes.key}:${cardType.name}"`) and use it for grid keys and card selection

## Test plan
- [ ] Open the Help/Explore screen on desktop and scroll through the card grid without crash
- [ ] Tap a Troika card tile and verify the bottom sheet opens for the correct variant
- [ ] Verify no other cards are affected by the key change

🤖 Generated with [Claude Code](https://claude.com/claude-code)